### PR TITLE
Add AUR instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,14 @@ cmdpxl has many exciting functionalities, including
 
 ## Installation
 
-Install the package with:
+PIP
 ```sh
 pip install cmdpxl
+```
+
+AUR
+```sh
+yay -S cmdpxl-git
 ```
 
 ## Usage


### PR DESCRIPTION
I've created a package for cmdpxl in the Arch User Repository.
https://aur.archlinux.org/packages/cmdpxl-git/

This pull request adds the necessary command to the readme for installing `cmdpxl-git` from the AUR as an alternative to using pip.